### PR TITLE
Improves OverlappingType definition.

### DIFF
--- a/maliput_object/include/maliput_object/api/overlapping_type.h
+++ b/maliput_object/include/maliput_object/api/overlapping_type.h
@@ -5,25 +5,25 @@ namespace object {
 namespace api {
 
 /// Holds the possible overlapping types between Objects' region.
-///  - Example of use:
-/// @code {.cpp}
-/// void MyMethod(OverlappingType type);
-/// ...
-/// MyMethod(OverlappingType::kContained | OverlappingType::kIntersected);
-/// @endcode
+///
+/// Given two sets `A` and `B` :
+/// - `A` intersects `B` iff `A` and `B` have at least one point in common.
+/// - `A` contains `B` iff `A` contains all the points of `B`.
+///   (Note that `A` contains `B` iff `A` intersects `B` and `B` contains `A`.)
+/// - `A` disjoints `B` iff `A` and `B` have no points in common.
+///
 ///  - Example of use:
 /// @code {.cpp}
 /// OverlappingType MyMethod();
 /// ...
-/// if(OverlappingType::kContained & MyMethod() == OverlappingType::kContained) {
+/// if(OverlappingType::kIntersected & MyMethod() == OverlappingType::kIntersected) {
 ///  // Do something.
 /// }
 /// @endcode
 enum class OverlappingType : unsigned int {
-  kDisjointed = 0,                   ///< No overlapping between bounding regions
-  kIntersected = 1 << 0,             ///< Bounding regions intersects.
-  kContained = 1 << 1,               ///< Entire bounding region is contained within another.
-  kAll = kIntersected | kContained,  ///< All overlapping types.
+  kDisjointed = 0,   ///< No overlapping between bounding regions
+  kIntersected = 1,  ///< Bounding regions are intersected.
+  kContained = 3,    ///< Bounding regions are contained.
 };
 
 // Union operator.

--- a/maliput_object/test/api/overlapping_type_test.cc
+++ b/maliput_object/test/api/overlapping_type_test.cc
@@ -10,9 +10,9 @@ namespace test {
 namespace {
 
 TEST(OverlappingTypeTest, TestOverlappingType) {
-  EXPECT_EQ(OverlappingType::kContained, OverlappingType::kContained & OverlappingType::kAll);
-  EXPECT_EQ(OverlappingType::kIntersected, OverlappingType::kIntersected & OverlappingType::kAll);
-  EXPECT_EQ(OverlappingType::kAll, OverlappingType::kIntersected | OverlappingType::kContained);
+  EXPECT_EQ(OverlappingType::kIntersected, OverlappingType::kContained & OverlappingType::kIntersected);
+  EXPECT_EQ(OverlappingType::kDisjointed, OverlappingType::kContained & OverlappingType::kDisjointed);
+  EXPECT_EQ(OverlappingType::kContained, (OverlappingType::kContained | OverlappingType::kIntersected));
 }
 
 }  // namespace


### PR DESCRIPTION
### Context
The definition of the enum was a bit misleading given that we were mixing two different descriptions of sets as if they were
exclusive options: Intersection and Subsets

### Summary
This PR improves the `OverlappingType` definition for a better description of the options, having in mind that
they are not exclusive and `Contains` implies `Intersection` but not vice-versa.