### PR TITLE
Use <doc_depend> for ament_cmake_doxygen dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <license file="LICENSE">BSD Clause 3</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>ament_cmake_doxygen</build_depend>
+  <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>fmt</depend>
   <depend>libgflags-dev</depend>


### PR DESCRIPTION
Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>
Related to https://github.com/maliput/maliput_infrastructure/issues/269
